### PR TITLE
Added invalid state

### DIFF
--- a/com.yakindu.sct.examples.coffeemachine.c/src/cm_trace.c
+++ b/com.yakindu.sct.examples.coffeemachine.c/src/cm_trace.c
@@ -12,6 +12,7 @@
 #include "sc/CoffeeMachineRequired.h"
 
 static char* stateNames[] = {
+		"InvalidState",
 		"Off",
 		"On" ,
 		"On.Welcome" ,


### PR DESCRIPTION
as we have the null state on the first position, we need an invalid state in the enum, otherwise, the index of the array will not fit anymore