### PR TITLE
Remove java builder from c++ project

### DIFF
--- a/org.yakindu.sct.examples.trafficlight.scxml.qt/.project
+++ b/org.yakindu.sct.examples.trafficlight.scxml.qt/.project
@@ -11,11 +11,6 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.jdt.core.javabuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
 			<name>org.yakindu.sct.builder.SCTBuilder</name>
 			<arguments>
 			</arguments>


### PR DESCRIPTION
Java builder is not needed and producing errors while generating code